### PR TITLE
Minting token implemented.

### DIFF
--- a/scripts/deploy-my-token.ts
+++ b/scripts/deploy-my-token.ts
@@ -2,22 +2,7 @@ import { ethers } from "ethers";
 import "dotenv/config";
 import * as myTokenJson from "../artifacts/contracts/Token.sol/MyToken.json";
 
-// This key is already public on Herong's Tutorial Examples - v1.03, by Dr. Herong Yang
-// Do never expose your keys like this
-const EXPOSED_KEY =
-  "8da4ef21b864d2cc526dbdb2a120bd2874c36c9d0a1fb7f8c63d7f7a8b41de8f";
-
-async function main() {
-  console.log("here");
-  const wallet =
-    process.env.MNEMONIC && process.env.MNEMONIC.length > 0
-      ? ethers.Wallet.fromMnemonic(process.env.MNEMONIC)
-      : new ethers.Wallet(process.env.PRIVATE_KEY ?? EXPOSED_KEY);
-  console.log("Using address: ", wallet.address);
-
-  const provider = ethers.providers.getDefaultProvider("ropsten");
-  const signer = wallet.connect(provider);
-
+async function main(signer: ethers.Wallet) {
   const balanceBN = await signer.getBalance();
   const balance = Number(ethers.utils.formatEther(balanceBN));
   console.log("Wallet balance: ", balance);

--- a/scripts/get-wallet-signer.ts
+++ b/scripts/get-wallet-signer.ts
@@ -1,0 +1,20 @@
+import { ethers } from "ethers";
+
+// This key is already public on Herong's Tutorial Examples - v1.03, by Dr. Herong Yang
+// Do never expose your keys like this
+const EXPOSED_KEY =
+  "8da4ef21b864d2cc526dbdb2a120bd2874c36c9d0a1fb7f8c63d7f7a8b41de8f";
+
+export const getWalletSigner = (
+  mnemonic?: string,
+  privateKey?: string,
+  providerNetwork = "ropsten"
+) => {
+  const wallet =
+    mnemonic && mnemonic.length > 0
+      ? ethers.Wallet.fromMnemonic(mnemonic)
+      : new ethers.Wallet(privateKey ?? EXPOSED_KEY);
+  const provider = ethers.providers.getDefaultProvider(providerNetwork);
+  const signer = wallet.connect(provider);
+  return signer;
+};

--- a/scripts/minting-token.ts
+++ b/scripts/minting-token.ts
@@ -1,0 +1,23 @@
+import { ethers } from "ethers";
+import "dotenv/config";
+// eslint-disable-next-line node/no-missing-import
+import { MyToken } from "../typechain";
+
+async function main(tokenContract: MyToken, mintAccount: ethers.Wallet) {
+  const BASE_VOTE_POWER = 10;
+
+  const preMintVotePower = await tokenContract.getVotes(mintAccount.address);
+  console.log("Premint vote power: ", preMintVotePower);
+
+  const mintTx = await tokenContract.mint(
+    mintAccount.address,
+    ethers.utils.parseEther(BASE_VOTE_POWER.toFixed(18))
+  );
+  await mintTx.wait();
+  console.log("Mint transaction: ", mintTx.hash);
+
+  const postMintVotePower = await tokenContract.getVotes(mintAccount.address);
+  console.log("Postmint vote power: ", postMintVotePower);
+}
+
+export default main;

--- a/scripts/operate.ts
+++ b/scripts/operate.ts
@@ -1,8 +1,32 @@
-// eslint-disable-next-line node/no-missing-import
+/* eslint-disable node/no-missing-import */
 import deployMyToken from "./deploy-my-token";
+import mintingToken from "./minting-token";
+import { getWalletSigner } from "./get-wallet-signer";
+import { MyToken } from "../typechain";
+import { Contract } from "ethers";
+import * as myTokenJson from "../artifacts/contracts/Token.sol/MyToken.json";
 
 async function main() {
-  const tokenContract = await deployMyToken();
+  const ownerSigner = getWalletSigner(undefined, process.env.PRIVATE_KEY);
+  console.log("Owner signer address: ", ownerSigner.address);
+
+  const contractAddress =
+    process.argv.length === 3 ? process.argv[2] : undefined;
+  const tokenContract: MyToken = contractAddress
+    ? (new Contract(contractAddress, myTokenJson.abi, ownerSigner) as MyToken)
+    : ((await deployMyToken(ownerSigner)) as MyToken);
+
+  const minterSigner = getWalletSigner(undefined, process.env.PRIVATE_KEY_2);
+  console.log("Minter signer address: ", minterSigner.address);
+
+  const minterRole = await tokenContract.MINTER_ROLE();
+  const minterRoleTx = await tokenContract.grantRole(
+    minterRole,
+    minterSigner.address
+  );
+  console.log("Minter role transaction: ", minterRoleTx.hash);
+
+  mintingToken(tokenContract, minterSigner);
 }
 
 main().catch((error) => {


### PR DESCRIPTION
Here is the minting script. 
To implement this I made some changes to deploy-my-token. We need more signers, so I extract the signer code to `getWalletSigner.ts`.

I added PRIVATE_KEY_2 to the env file to use it as a miner.

I also added logic to the `operate.ts` to use the same contract instead of creating new for each try.
You can use it like that `yarn ts-node scripts/operate.ts 0x430a56a1d18caec901576053053219818529bb0f
`
